### PR TITLE
Use builtin stats as database

### DIFF
--- a/const.py
+++ b/const.py
@@ -11,3 +11,36 @@ CONF_CUPS = "cups"
 CONF_PROVIDER = "provider"
 CONF_EXPERIMENTAL = "experimental"
 CONF_DEBUG = "debug"
+
+# sensor attributes
+ATTRIBUTES = {
+    "cups": None,
+    "contract_p1_kW": "kW",
+    "contract_p2_kW": "kW",
+    "yesterday_kWh": "kWh",
+    "yesterday_hours": "h",
+    "yesterday_p1_kWh": "kWh",
+    "yesterday_p2_kWh": "kWh",
+    "yesterday_p3_kWh": "kWh",
+    "month_kWh": "kWh",
+    "month_daily_kWh": "kWh",
+    "month_days": "d",
+    "month_p1_kWh": "kWh",
+    "month_p2_kWh": "kWh",
+    "month_p3_kWh": "kWh",
+    # "month_pvpc_€": '€',
+    "last_month_kWh": "kWh",
+    "last_month_daily_kWh": "kWh",
+    "last_month_days": "d",
+    "last_month_p1_kWh": "kWh",
+    "last_month_p2_kWh": "kWh",
+    "last_month_p3_kWh": "kWh",
+    # "last_month_pvpc_€": '€',
+    # "last_month_idle_W": 'W',
+    "max_power_kW": "kW",
+    "max_power_date": None,
+    "max_power_mean_kW": "kW",
+    "max_power_90perc_kW": "kW",
+}
+
+EXPERIMENTAL_ATTRS = []

--- a/coordinator.py
+++ b/coordinator.py
@@ -1,0 +1,442 @@
+import logging
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
+
+from edata.processors import DataUtils as du
+from homeassistant.core import HomeAssistant
+from homeassistant.components.recorder.const import DATA_INSTANCE
+from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    clear_statistics,
+    get_last_statistics,
+    statistics_during_period,
+    month_start_end,
+    day_start_end,
+)
+from homeassistant.helpers.storage import Store
+from homeassistant.helpers.update_coordinator import (
+    DataUpdateCoordinator,
+)
+from homeassistant.const import (
+    ENERGY_KILO_WATT_HOUR,
+    POWER_KILO_WATT,
+)
+
+from homeassistant.util import dt as dt_util
+
+from .const import *
+from .websockets import *
+from edata.connectors import DatadisConnector
+from .store import DateTimeEncoder
+
+import numpy as np
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EdataCoordinator(DataUpdateCoordinator):
+    """Handle Datadis data and statistics."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        username: str,
+        password: str,
+        cups: str,
+        prev_data=None,
+    ) -> None:
+        """Initialize the data handler."""
+        self.hass = hass
+        self.reset = prev_data is None
+
+        self._experimental = False
+        self._cups = cups.upper()
+        self.id = self._cups[-4:].lower()
+
+        self._data = {
+            "state": STATE_LOADING,
+            "attributes": {x: None for x in ATTRIBUTES},
+        }
+        if prev_data is not None:
+            self._data.update(prev_data)
+
+        self.consumption_stats = ["p1_kWh", "p2_kWh", "p3_kWh", "kWh"]
+        self.maximeter_stats = ["p1_kW", "p2_kW", "p3_kW", "kW"]
+
+        hass.data[DOMAIN][self.id.upper()] = {}
+
+        self.stat_ids = {
+            "kWh": f"{DOMAIN}:{self.id}_consumption",
+            "p1_kWh": f"{DOMAIN}:{self.id}_p1_consumption",
+            "p2_kWh": f"{DOMAIN}:{self.id}_p2_consumption",
+            "p3_kWh": f"{DOMAIN}:{self.id}_p3_consumption",
+            "kW": f"{DOMAIN}:{self.id}_maximeter",
+            "p1_kW": f"{DOMAIN}:{self.id}_p1_maximeter",
+            "p2_kW": f"{DOMAIN}:{self.id}_p2_maximeter",
+            "p3_kW": f"{DOMAIN}:{self.id}_p3_maximeter",
+        }
+
+        self._datadis = DatadisConnector(username, password, data=prev_data)
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"edata_{self.id}",
+            update_interval=timedelta(minutes=60),
+        )
+
+    async def _async_update_data(self):
+        """Update data via API."""
+        # reset stats if no storage file was found
+        if self.reset:
+            _LOGGER.warning(
+                "Clearing statistics for %s",
+                [self.stat_ids[x] for x in self.stat_ids],
+            )
+            await self.hass.async_add_executor_job(
+                clear_statistics,
+                self.hass.data[DATA_INSTANCE],
+                [self.stat_ids[x] for x in self.stat_ids],
+            )
+
+        # fetch last statistics found
+        last_stats = {
+            x: await self.hass.async_add_executor_job(
+                get_last_statistics, self.hass, 1, self.stat_ids[x], True
+            )
+            for x in self.stat_ids
+        }
+
+        # retrieve sum for summable stats (consumptions)
+        _sum = {
+            x: last_stats[x][self.stat_ids[x]][0].get("sum", 0) if last_stats[x] else 0
+            for x in self.consumption_stats
+        }
+
+        try:
+            last_kWh_record = last_stats["kWh"][self.stat_ids["kWh"]][0]["end"]
+            _LOGGER.info("Last consumptions record was at %s", last_kWh_record)
+        except KeyError as _:
+            last_kWh_record = None
+            _LOGGER.warning("No consumption stats found")
+
+        try:
+            last_kW_record = last_stats["kW"][self.stat_ids["kW"]][0]["end"]
+            _LOGGER.info("Last maximeter record was at %s", last_kW_record)
+        except KeyError as _:
+            last_kW_record = None
+            _LOGGER.warning("No maximeter stats found")
+
+        await self.hass.async_add_executor_job(
+            self._datadis.update,
+            self._cups,
+            min(
+                dt_util.parse_datetime(last_kWh_record).replace(tzinfo=None),
+                dt_util.parse_datetime(last_kW_record).replace(tzinfo=None),
+                datetime.today() - timedelta(days=30),
+            )
+            if last_kWh_record is not None and last_kW_record is not None
+            else datetime(1970, 1, 1),
+            datetime.today(),
+        )
+
+        self._data.update(self._datadis.data)
+
+        new_stats = {x: [] for x in self.stat_ids}
+        something_changed = False
+
+        _LABEL_kWh = "value_kWh"
+        for data in self._datadis.data.get("consumptions", {}):
+            if last_kWh_record is None or dt_util.as_local(
+                data["datetime"]
+            ) >= dt_util.parse_datetime(last_kWh_record):
+                something_changed = True
+                _p = du.get_pvpc_tariff(data["datetime"])
+                _sum["kWh"] += data[_LABEL_kWh]
+                new_stats["kWh"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]),
+                        state=data[_LABEL_kWh],
+                        sum=_sum["kWh"],
+                    )
+                )
+                _sum[_p + "_kWh"] += data[_LABEL_kWh]
+                new_stats[_p + "_kWh"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]),
+                        state=data[_LABEL_kWh],
+                        sum=_sum[_p + "_kWh"],
+                    )
+                )
+
+        _LABEL_kW = "value_kW"
+        for data in self._datadis.data.get("maximeter", {}):
+            if last_kW_record is None or dt_util.as_local(
+                data["datetime"]
+            ) >= dt_util.parse_datetime(last_kW_record):
+                something_changed = True
+                _p = du.get_pvpc_tariff(data["datetime"])
+                new_stats["kW"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]).replace(minute=0),
+                        state=data[_LABEL_kW],
+                        mean=data[_LABEL_kW],
+                    )
+                )
+                new_stats[_p + "_kW"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]).replace(minute=0),
+                        state=data[_LABEL_kW],
+                        mean=data[_LABEL_kW],
+                    )
+                )
+
+        for _scope in self.consumption_stats:
+            metadata = StatisticMetaData(
+                has_mean=False,
+                has_sum=True,
+                name=f"{DOMAIN}_{self.id} {_scope} energy consumption",
+                source=DOMAIN,
+                statistic_id=self.stat_ids[_scope],
+                unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+            )
+            _LOGGER.info("Adding new stats to %s", self.stat_ids[_scope])
+            async_add_external_statistics(self.hass, metadata, new_stats[_scope])
+
+        for _scope in self.maximeter_stats:
+            metadata = StatisticMetaData(
+                has_mean=True,
+                has_sum=False,
+                name=f"{DOMAIN}_{self.id} {_scope} maximeter",
+                source=DOMAIN,
+                statistic_id=self.stat_ids[_scope],
+                unit_of_measurement=POWER_KILO_WATT,
+            )
+            _LOGGER.info("Adding new stats to %s", self.stat_ids[_scope])
+            async_add_external_statistics(self.hass, metadata, new_stats[_scope])
+
+        # compile state and attributes
+        if something_changed or self._data.get("state", STATE_LOADING) != STATE_READY:
+            ## Load contractual data
+            await self.load_data()
+
+        return self._data
+
+    async def load_data(self):
+
+        attrs = {x: None for x in ATTRIBUTES}
+
+        # add supplies-related attributes
+        attrs.update(
+            {
+                "cups": self._cups
+                if self._cups in [x["cups"] for x in self._data["supplies"]]
+                else None
+            }
+        )
+
+        # add contract-related attributes
+        attrs.update(
+            {
+                "contract_p1_kW": self._data["contracts"][-1].get("power_p1", None)
+                if len(self._data["contracts"]) > 0
+                else None,
+                "contract_p2_kW": self._data["contracts"][-1].get("power_p2", None)
+                if len(self._data["contracts"]) > 0
+                else None,
+            }
+        )
+
+        last_stats = {
+            x: await self.hass.async_add_executor_job(
+                get_last_statistics, self.hass, 1, self.stat_ids[x], True
+            )
+            for x in self.stat_ids
+        }
+
+        last_records = {
+            x: dt_util.as_local(
+                dt_util.parse_datetime(last_stats[x][self.stat_ids[x]][0]["end"])
+            )
+            for x in self.stat_ids
+        }
+
+        # Load consumptions
+        compiled_stats = {}
+        for _aggr_method in ("month", "day"):
+            _stats = await self.hass.async_add_executor_job(
+                statistics_during_period,
+                self.hass,
+                dt_util.as_local(datetime(1970, 1, 1)),
+                None,
+                [self.stat_ids[x] for x in self.consumption_stats],
+                _aggr_method,
+            )
+            compiled_stats[_aggr_method] = {}
+            for key in _stats:
+                _sum = 0
+                for stat in _stats[key]:
+                    _dt = dt_util.as_local(dt_util.parse_datetime(stat["start"]))
+                    isodate = _dt.isoformat()
+                    if isodate not in compiled_stats[_aggr_method]:
+                        compiled_stats[_aggr_method][isodate] = {
+                            "datetime": isodate,
+                            "value_kWh": 0,
+                            "value_p1_kWh": 0,
+                            "value_p2_kWh": 0,
+                            "value_p3_kWh": 0,
+                        }
+                    for _scope in self.consumption_stats:
+                        if self.stat_ids[_scope] == stat["statistic_id"]:
+                            _key = f"value_{_scope}"
+                            _inc = round(stat["sum"] - _sum, 1)
+                            compiled_stats[_aggr_method][isodate][_key] = _inc
+                            _sum = stat["sum"]
+                            if _inc < 0:
+                                return False
+                            break
+
+            # load into websockets
+            self.hass.data[DOMAIN][self.id.upper()][
+                f"ws_consumptions_{_aggr_method}"
+            ] = sorted(
+                [compiled_stats[_aggr_method][x] for x in compiled_stats[_aggr_method]],
+                key=lambda d: dt_util.parse_datetime(d["datetime"]),
+            )
+
+        # yesterday attributes
+        ydates = day_start_end(datetime.now() - timedelta(days=1))
+        _date_str = dt_util.as_local(ydates[0]).isoformat()
+        if _date_str in compiled_stats["day"]:
+            attrs["yesterday_kWh"] = compiled_stats["day"][_date_str]["value_kWh"]
+            attrs["yesterday_p1_kWh"] = compiled_stats["day"][_date_str]["value_p1_kWh"]
+            attrs["yesterday_p2_kWh"] = compiled_stats["day"][_date_str]["value_p2_kWh"]
+            attrs["yesterday_p3_kWh"] = compiled_stats["day"][_date_str]["value_p3_kWh"]
+            attrs["yesterday_hours"] = round(
+                (
+                    last_records["kWh"]
+                    - last_records["kWh"].replace(
+                        hour=0, minute=0, second=0, microsecond=0
+                    )
+                ).seconds
+                / 3600,
+                2,
+            )
+        # current month attributes
+        cmdates = month_start_end(datetime.now().replace(day=1))
+        _date_str = dt_util.as_local(cmdates[0]).isoformat()
+        if _date_str in compiled_stats["month"]:
+            attrs["month_kWh"] = compiled_stats["month"][_date_str]["value_kWh"]
+            attrs["month_p1_kWh"] = compiled_stats["month"][_date_str]["value_p1_kWh"]
+            attrs["month_p2_kWh"] = compiled_stats["month"][_date_str]["value_p2_kWh"]
+            attrs["month_p3_kWh"] = compiled_stats["month"][_date_str]["value_p3_kWh"]
+            attrs["month_days"] = round(
+                (
+                    last_records["kWh"]
+                    - last_records["kWh"].replace(
+                        day=1, hour=0, minute=0, second=0, microsecond=0
+                    )
+                ).days
+            )
+            attrs["month_daily_kWh"] = round(
+                attrs["month_kWh"] / attrs["month_days"], 1
+            )
+        # last month attributes
+        lmdates = month_start_end(cmdates[0] - relativedelta(months=1))
+        _date_str = dt_util.as_local(lmdates[0]).isoformat()
+        if _date_str in compiled_stats["month"]:
+            attrs["last_month_kWh"] = compiled_stats["month"][_date_str]["value_kWh"]
+            attrs["last_month_p1_kWh"] = compiled_stats["month"][_date_str][
+                "value_p1_kWh"
+            ]
+            attrs["last_month_p2_kWh"] = compiled_stats["month"][_date_str][
+                "value_p2_kWh"
+            ]
+            attrs["last_month_p3_kWh"] = compiled_stats["month"][_date_str][
+                "value_p3_kWh"
+            ]
+            attrs["last_month_days"] = round(
+                (
+                    last_records["kWh"].replace(
+                        day=1, hour=0, minute=0, second=0, microsecond=0
+                    )
+                    - (
+                        last_records["kWh"].replace(
+                            day=1, hour=0, minute=0, second=0, microsecond=0
+                        )
+                        - relativedelta(months=1)
+                    )
+                ).days,
+                2,
+            )
+            attrs["last_month_daily_kWh"] = round(
+                attrs["last_month_kWh"] / attrs["last_month_days"], 1
+            )
+
+        # Load maximeter
+        _stats = await self.hass.async_add_executor_job(
+            statistics_during_period,
+            self.hass,
+            dt_util.as_local(datetime(1970, 1, 1)),
+            None,
+            [self.stat_ids[x] for x in self.maximeter_stats],
+            "hour",
+        )
+
+        compiled_stats = {}
+        for key in _stats:
+            for stat in _stats[key]:
+                _dt = dt_util.as_local(dt_util.parse_datetime(stat["start"]))
+                isodate = _dt.isoformat()
+                if isodate not in compiled_stats:
+                    compiled_stats[isodate] = {
+                        "datetime": isodate,
+                        "value_kW": 0,
+                        "value_p1_kW": 0,
+                        "value_p2_kW": 0,
+                        "value_p3_kW": 0,
+                    }
+                for _scope in self.maximeter_stats:
+                    if self.stat_ids[_scope] == stat["statistic_id"]:
+                        _key = f"value_{_scope}"
+                        compiled_stats[isodate][_key] = round(stat["mean"], 1)
+                        break
+
+        # load into websockets
+        self.hass.data[DOMAIN][self.id.upper()]["ws_maximeter"] = sorted(
+            [compiled_stats[x] for x in compiled_stats],
+            key=lambda d: dt_util.parse_datetime(d["datetime"]),
+        )
+
+        max_date = None
+        max_value = 0
+        for record in self.hass.data[DOMAIN][self.id.upper()]["ws_maximeter"]:
+            if record["value_kW"] > max_value:
+                max_value = record["value_kW"]
+                max_date = record["datetime"]
+
+        values = np.array(
+            [
+                x["value_kW"]
+                for x in self.hass.data[DOMAIN][self.id.upper()]["ws_maximeter"]
+            ]
+        )
+
+        attrs["max_power_kW"] = max_value
+        attrs["max_power_date"] = max_date
+        attrs["max_power_mean_kW"] = round(np.mean(values), 1)
+        attrs["max_power_90perc_kW"] = round(np.percentile(values, 90), 1)
+
+        # update attributes
+        self._data["state"] = STATE_READY
+        self._data["attributes"].update(attrs)
+
+        await Store(
+            self.hass,
+            STORAGE_VERSION,
+            f"{STORAGE_KEY_PREAMBLE}_{self.id.upper()}",
+            encoder=DateTimeEncoder,
+        ).async_save({x: self._datadis.data[x] for x in ["supplies", "contracts"]})
+
+        return True

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "issue_tracker": "https://github.com/uvejota/homeassistant-edata/issues",
     "dependencies": ["recorder"],
     "codeowners": ["@uvejota"],
-    "requirements": ["e-data==0.3.9", "python-dateutil==2.8.2", "numpy==1.22.1"],
+    "requirements": ["e-data==0.3.9", "python-dateutil==2.8.2", "numpy==1.19.5"],
     "version": "2021.12.2",
     "iot_class": "cloud_polling",
     "config_flow": true

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "issue_tracker": "https://github.com/uvejota/homeassistant-edata/issues",
     "dependencies": ["recorder"],
     "codeowners": ["@uvejota"],
-    "requirements": ["e-data==0.3.9", "python-dateutil==2.8.2"],
+    "requirements": ["e-data==0.3.9", "python-dateutil==2.8.2", "numpy==1.22.1"],
     "version": "2021.12.2",
     "iot_class": "cloud_polling",
     "config_flow": true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 e-data == 0.3.9
 python-dateutil == 2.8.2
-numpy == 1.22.1
+numpy == 1.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 e-data == 0.3.9
 python-dateutil == 2.8.2
+numpy == 1.22.1

--- a/sensor.py
+++ b/sensor.py
@@ -1,28 +1,13 @@
 import logging
-from datetime import datetime, timedelta
-from dateutil.relativedelta import relativedelta
 import voluptuous as vol
-from edata.helpers import EdataHelper
-from edata.processors import DataUtils as du
-from homeassistant.core import HomeAssistant
-from homeassistant.components.recorder.const import DATA_INSTANCE
-from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
-from homeassistant.components.recorder.statistics import (
-    async_add_external_statistics,
-    clear_statistics,
-    get_last_statistics,
-    statistics_during_period,
-    month_start_end,
-    day_start_end,
-)
+from .coordinator import EdataCoordinator
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
-    ENERGY_KILO_WATT_HOUR,
     EVENT_HOMEASSISTANT_START,
-    POWER_KILO_WATT,
 )
 from homeassistant.core import CoreState, callback
 from homeassistant.helpers import config_validation as cv
@@ -30,19 +15,13 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
-    DataUpdateCoordinator,
 )
-from homeassistant.util import dt as dt_util
-
-from .const import *
 from .store import DateTimeEncoder, async_load_storage
 from .websockets import *
-from edata.connectors import DatadisConnector
+from .const import *
 
 # HA variables
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = timedelta(minutes=60)
-
 
 PLATFORM_SCHEMA = vol.All(
     cv.deprecated(CONF_USERNAME),
@@ -138,7 +117,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     coordinator = EdataCoordinator(hass, usr, pwd, cups, prev_data)
     if prev_data is not None:
-        await coordinator.compile_attributes()
+        await coordinator.load_data()
 
     # postpone first refresh to speed up startup
     @callback
@@ -152,7 +131,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_first_refresh)
 
     # build sensor entities
-
     entities = []
     entities.append(EdataSensor(coordinator))
     async_add_entities(entities)
@@ -177,8 +155,10 @@ class EdataSensor(CoordinatorEntity, SensorEntity):
         """Return the state of the sensor."""
         try:
             return self.coordinator.data.get("state", None)
+        except AttributeError as _:
+            return STATE_LOADING
         except Exception as _:
-            return STATE_LOADING if self.coordinator.data is None else STATE_ERROR
+            return STATE_ERROR
 
     @property
     def extra_state_attributes(self):
@@ -187,296 +167,3 @@ class EdataSensor(CoordinatorEntity, SensorEntity):
             return self.coordinator.data.get("attributes", {})
         except Exception as _:
             return {}
-
-
-class EdataCoordinator(DataUpdateCoordinator):
-    """Handle Datadis data and statistics."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        username: str,
-        password: str,
-        cups: str,
-        prev_data=None,
-    ) -> None:
-        """Initialize the data handler."""
-        self.hass = hass
-        self.reset = prev_data is None
-
-        self._experimental = False
-        self._cups = cups.upper()
-        self.id = self._cups[-4:].lower()
-
-        self._data = {
-            "state": STATE_LOADING,
-            "attributes": {x: None for x in ATTRIBUTES},
-        }
-        if prev_data is not None:
-            self._data.update(prev_data)
-
-        self.consumption_stats = ["p1_kWh", "p2_kWh", "p3_kWh", "kWh"]
-        self.maximeter_stats = ["p1_kW", "p2_kW", "p3_kW", "kW"]
-
-        hass.data[DOMAIN][self.id.upper()] = {}
-
-        self.stat_ids = {
-            "kWh": f"{DOMAIN}:{self.id}_consumption",
-            "p1_kWh": f"{DOMAIN}:{self.id}_p1_consumption",
-            "p2_kWh": f"{DOMAIN}:{self.id}_p2_consumption",
-            "p3_kWh": f"{DOMAIN}:{self.id}_p3_consumption",
-            "kW": f"{DOMAIN}:{self.id}_maximeter",
-            "p1_kW": f"{DOMAIN}:{self.id}_p1_maximeter",
-            "p2_kW": f"{DOMAIN}:{self.id}_p2_maximeter",
-            "p3_kW": f"{DOMAIN}:{self.id}_p3_maximeter",
-        }
-
-        self._datadis = DatadisConnector(username, password, data=prev_data)
-
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=f"edata_{self.id}",
-            update_interval=SCAN_INTERVAL,
-        )
-
-    async def _async_update_data(self):
-        """Update data via API."""
-        # reset stats if no storage file was found
-        if self.reset:
-            _LOGGER.warning(
-                "Clearing statistics for %s",
-                [self.stat_ids[x] for x in self.stat_ids],
-            )
-            await self.hass.async_add_executor_job(
-                clear_statistics,
-                self.hass.data[DATA_INSTANCE],
-                [self.stat_ids[x] for x in self.stat_ids],
-            )
-
-        # fetch last statistics found
-        last_stats = {
-            x: await self.hass.async_add_executor_job(
-                get_last_statistics, self.hass, 1, self.stat_ids[x], True
-            )
-            for x in self.stat_ids
-        }
-
-        # retrieve sum for summable stats (consumptions)
-        _sum = {
-            x: last_stats[x][self.stat_ids[x]][0].get("sum", 0) if last_stats[x] else 0
-            for x in self.consumption_stats
-        }
-
-        try:
-            last_kWh_record = last_stats["kWh"][self.stat_ids["kWh"]][0]["end"]
-            _LOGGER.info("Last consumptions record was at %s", last_kWh_record)
-        except KeyError as _:
-            last_kWh_record = None
-            _LOGGER.warning("No consumption stats found")
-
-        try:
-            last_kW_record = last_stats["kW"][self.stat_ids["kW"]][0]["end"]
-            _LOGGER.info("Last maximeter record was at %s", last_kW_record)
-        except KeyError as _:
-            last_kW_record = None
-            _LOGGER.warning("No maximeter stats found")
-
-        await self.hass.async_add_executor_job(
-            self._datadis.update,
-            self._cups,
-            min(
-                dt_util.parse_datetime(last_kWh_record).replace(tzinfo=None),
-                dt_util.parse_datetime(last_kW_record).replace(tzinfo=None),
-                datetime.today() - timedelta(days=30),
-            )
-            if last_kWh_record is not None and last_kW_record is not None
-            else datetime(1970, 1, 1),
-            datetime.today(),
-        )
-
-        self._data.update(self._datadis.data)
-
-        new_stats = {x: [] for x in self.stat_ids}
-        something_changed = False
-
-        _LABEL_kWh = "value_kWh"
-        for data in self._datadis.data.get("consumptions", {}):
-            if last_kWh_record is None or dt_util.as_local(
-                data["datetime"]
-            ) >= dt_util.parse_datetime(last_kWh_record):
-                something_changed = True
-                _p = du.get_pvpc_tariff(data["datetime"])
-                _sum["kWh"] += data[_LABEL_kWh]
-                new_stats["kWh"].append(
-                    StatisticData(
-                        start=dt_util.as_local(data["datetime"]),
-                        state=data[_LABEL_kWh],
-                        mean=data[_LABEL_kWh],
-                        sum=_sum["kWh"],
-                    )
-                )
-                _sum[_p + "_kWh"] += data[_LABEL_kWh]
-                new_stats[_p + "_kWh"].append(
-                    StatisticData(
-                        start=dt_util.as_local(data["datetime"]),
-                        state=data[_LABEL_kWh],
-                        mean=data[_LABEL_kWh],
-                        sum=_sum[_p + "_kWh"],
-                    )
-                )
-
-        _LABEL_kW = "value_kW"
-        for data in self._datadis.data.get("maximeter", {}):
-            if last_kW_record is None or dt_util.as_local(
-                data["datetime"]
-            ) >= dt_util.parse_datetime(last_kW_record):
-                something_changed = True
-                _p = du.get_pvpc_tariff(data["datetime"])
-                new_stats["kW"].append(
-                    StatisticData(
-                        start=dt_util.as_local(data["datetime"]).replace(minute=0),
-                        state=data[_LABEL_kW],
-                        mean=data[_LABEL_kW],
-                    )
-                )
-                new_stats[_p + "_kW"].append(
-                    StatisticData(
-                        start=dt_util.as_local(data["datetime"]).replace(minute=0),
-                        state=data[_LABEL_kW],
-                        mean=data[_LABEL_kW],
-                    )
-                )
-
-        for _scope in self.consumption_stats:
-            metadata = StatisticMetaData(
-                has_mean=True,
-                has_sum=True,
-                name=f"{DOMAIN}_{self.id} {_scope} energy consumption",
-                source=DOMAIN,
-                statistic_id=self.stat_ids[_scope],
-                unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-            )
-            _LOGGER.info("adding new stats to %s", self.stat_ids[_scope])
-            async_add_external_statistics(self.hass, metadata, new_stats[_scope])
-
-        for _scope in self.maximeter_stats:
-            metadata = StatisticMetaData(
-                has_mean=True,
-                has_sum=False,
-                name=f"{DOMAIN}_{self.id} {_scope} maximeter",
-                source=DOMAIN,
-                statistic_id=self.stat_ids[_scope],
-                unit_of_measurement=POWER_KILO_WATT,
-            )
-            _LOGGER.info("adding new stats to %s", self.stat_ids[_scope])
-            async_add_external_statistics(self.hass, metadata, new_stats[_scope])
-
-        # compile state and attributes
-        if something_changed or self._data.get("state", STATE_LOADING) == STATE_LOADING:
-            # update state and attributes
-            self._data["state"] = STATE_READY
-            if (
-                False == await self.compile_attributes()
-            ):  # wipe data if something got wrong
-                _LOGGER.warning("Inconsistent data found, rebuilding statistics")
-                self.reset = True
-                await self._async_update_data()
-            # store if 24hs
-
-        return self._data
-
-    async def compile_attributes(self) -> bool:
-        """Load statistics and compile attributes and websockets, return false if failed"""
-        compiled_stats = {}
-
-        # load contractual data
-        attrs = {
-            "cups": self._cups
-            if self._cups in [x["cups"] for x in self._data["supplies"]]
-            else None,
-            "contract_p1_kW": self._data["contracts"][-1].get("power_p1", None)
-            if len(self._data["contracts"]) > 0
-            else None,
-            "contract_p2_kW": self._data["contracts"][-1].get("power_p2", None)
-            if len(self._data["contracts"]) > 0
-            else None,
-        }
-
-        # load consumptions
-        for _aggr_method in ("month", "day"):
-            _stats = await self.hass.async_add_executor_job(
-                statistics_during_period,
-                self.hass,
-                dt_util.as_local(datetime(1970, 1, 1)),
-                None,
-                [self.stat_ids[x] for x in self.consumption_stats],
-                _aggr_method,
-            )
-            compiled_stats[_aggr_method] = {}
-            for hourly_stat in _stats:
-                _sum = 0
-                for i in _stats[hourly_stat]:
-                    _dt = dt_util.as_local(dt_util.parse_datetime(i["start"]))
-                    date = _dt.isoformat()
-                    if date not in compiled_stats[_aggr_method]:
-                        compiled_stats[_aggr_method][date] = {
-                            "datetime": date,
-                            "value_kWh": 0,
-                            "value_p1_kWh": 0,
-                            "value_p2_kWh": 0,
-                            "value_p3_kWh": 0,
-                        }
-                    for _scope in self.consumption_stats:
-                        if self.stat_ids[_scope] == i["statistic_id"]:
-                            _key = f"value_{_scope}"
-                            _inc = round(i["sum"] - _sum, 2)
-                            compiled_stats[_aggr_method][date][_key] = _inc
-                            _sum = i["sum"]
-                            if _inc < 0:
-                                return False
-                            break
-
-            # load into websockets
-            self.hass.data[DOMAIN][self.id.upper()][
-                f"ws_consumptions_{_aggr_method}"
-            ] = sorted(
-                [compiled_stats[_aggr_method][x] for x in compiled_stats[_aggr_method]],
-                key=lambda d: dt_util.parse_datetime(d["datetime"]),
-            )
-
-        # load yesterday attributes
-        ydates = day_start_end(datetime.now() - timedelta(days=1))
-        _date_str = dt_util.as_local(ydates[0]).isoformat()
-        if _date_str in compiled_stats["day"]:
-            attrs["yesterday_kWh"] = compiled_stats["day"][_date_str]["value_kWh"]
-            attrs["yesterday_p1_kWh"] = compiled_stats["day"][_date_str]["value_p1_kWh"]
-            attrs["yesterday_p2_kWh"] = compiled_stats["day"][_date_str]["value_p2_kWh"]
-            attrs["yesterday_p3_kWh"] = compiled_stats["day"][_date_str]["value_p3_kWh"]
-        # load current month attributes
-        cmdates = month_start_end(datetime.now().replace(day=1))
-        _date_str = dt_util.as_local(cmdates[0]).isoformat()
-        if _date_str in compiled_stats["month"]:
-            attrs["month_kWh"] = compiled_stats["month"][_date_str]["value_kWh"]
-            attrs["month_p1_kWh"] = compiled_stats["month"][_date_str]["value_p1_kWh"]
-            attrs["month_p2_kWh"] = compiled_stats["month"][_date_str]["value_p2_kWh"]
-            attrs["month_p3_kWh"] = compiled_stats["month"][_date_str]["value_p3_kWh"]
-        # load last month attributes
-        lmdates = month_start_end(cmdates[0] - relativedelta(months=1))
-        _date_str = dt_util.as_local(lmdates[0]).isoformat()
-        if _date_str in compiled_stats["month"]:
-            attrs["last_month_kWh"] = compiled_stats["month"][_date_str]["value_kWh"]
-            attrs["last_month_p1_kWh"] = compiled_stats["month"][_date_str][
-                "value_p1_kWh"
-            ]
-            attrs["last_month_p2_kWh"] = compiled_stats["month"][_date_str][
-                "value_p2_kWh"
-            ]
-            attrs["last_month_p3_kWh"] = compiled_stats["month"][_date_str][
-                "value_p3_kWh"
-            ]
-
-        # update attributes
-        self._data["attributes"].update(attrs)
-
-        return True

--- a/sensor.py
+++ b/sensor.py
@@ -1,34 +1,47 @@
 import logging
 from datetime import datetime, timedelta
-
+from dateutil.relativedelta import relativedelta
 import voluptuous as vol
 from edata.helpers import EdataHelper
 from edata.processors import DataUtils as du
+from homeassistant.core import HomeAssistant
 from homeassistant.components.recorder.const import DATA_INSTANCE
-from homeassistant.components.recorder.models import (StatisticData,
-                                                      StatisticMetaData)
+from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
 from homeassistant.components.recorder.statistics import (
-    async_add_external_statistics, clear_statistics, get_last_statistics)
+    async_add_external_statistics,
+    clear_statistics,
+    get_last_statistics,
+    statistics_during_period,
+    month_start_end,
+    day_start_end,
+)
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME,
-                                 ENERGY_KILO_WATT_HOUR,
-                                 EVENT_HOMEASSISTANT_START)
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    ENERGY_KILO_WATT_HOUR,
+    EVENT_HOMEASSISTANT_START,
+    POWER_KILO_WATT,
+)
 from homeassistant.core import CoreState, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.storage import Store
-from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
-                                                      DataUpdateCoordinator)
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 from homeassistant.util import dt as dt_util
 
 from .const import *
 from .store import DateTimeEncoder, async_load_storage
 from .websockets import *
+from edata.connectors import DatadisConnector
 
 # HA variables
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = timedelta(minutes=30)
+SCAN_INTERVAL = timedelta(minutes=60)
 
 
 PLATFORM_SCHEMA = vol.All(
@@ -111,137 +124,21 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     experimental = config_entry.data[CONF_EXPERIMENTAL]
 
     # load old data if any
+
     store = Store(
         hass,
         STORAGE_VERSION,
         f"{STORAGE_KEY_PREAMBLE}_{scups}",
         encoder=DateTimeEncoder,
     )
-    prev_data = await async_load_storage(store)
-    if prev_data:
-        api = EdataHelper(
-            "datadis", usr, pwd, cups, data=prev_data, experimental=experimental
-        )
-        api.process_data()
-        hass.data[DOMAIN][scups] = api.data
-    else:
-        api = EdataHelper("datadis", usr, pwd, cups, experimental=experimental)
-
-    async def async_update_data():
-        """Fetch data from edata endpoint."""
-        try:
-            last_changed = api.attributes.get("last_registered_kWh_date", None)
-            await hass.async_add_executor_job(api.update)
-            hass.data[DOMAIN][scups] = api.data
-            if last_changed is None or (
-                api.attributes.get(
-                    "last_registered_kWh_date", datetime(1970, 1, 1))
-                - last_changed
-            ) > timedelta(hours=24):
-                await store.async_save(api.data)
-            await _insert_statistics(last_changed is None)
-            return {
-                "state": STATE_READY,
-                "attributes": api.attributes,
-                "data": hass.data[DOMAIN][scups],
-            }
-        except Exception as e:
-            _LOGGER.exception("unhandled exception when updating data %s", e)
-            return {
-                "state": STATE_ERROR,
-                "attributes": api.attributes,
-                "data": hass.data[DOMAIN][scups],
-            }
-
-    async def _insert_statistics(reset=False):
-        """Insert edata statistics"""
-        statistic_id = {}
-        statistic_id["total"] = f"{DOMAIN}:{scups.lower()}_consumption"
-        statistic_id["p1"] = f"{DOMAIN}:{scups.lower()}_p1_consumption"
-        statistic_id["p2"] = f"{DOMAIN}:{scups.lower()}_p2_consumption"
-        statistic_id["p3"] = f"{DOMAIN}:{scups.lower()}_p3_consumption"
-
-        last_stats = {
-            x: await hass.async_add_executor_job(
-                get_last_statistics, hass, 1, statistic_id[x], True
-            )
-            for x in ["total", "p1", "p2", "p3"]
-        }
-
-        _sum = {
-            x: last_stats[x][statistic_id[x]][0].get("sum", 0)
-            if last_stats[x] and not reset
-            else 0
-            for x in ["total", "p1", "p2", "p3"]
-        }
-
-        statistics = {"total": [], "p1": [], "p2": [], "p3": []}
-
-        if reset:
-            _LOGGER.warning(
-                f"clearing statistics for {[statistic_id[x] for x in statistic_id]}"
-            )
-            await hass.async_add_executor_job(
-                clear_statistics,
-                hass.data[DATA_INSTANCE],
-                [statistic_id[x] for x in statistic_id],
-            )
-
-        try:
-            last_stats_time = last_stats["total"][statistic_id["total"]][0]["end"]
-        except KeyError as e:
-            last_stats_time = None
-
-        for data in api.data.get("consumptions", {}):
-            if (
-                reset
-                or last_stats_time is None
-                or dt_util.as_local(data["datetime"])
-                >= dt_util.parse_datetime(last_stats_time)
-            ):
-                _p = du.get_pvpc_tariff(data["datetime"])
-                _sum["total"] += data["value_kWh"]
-                statistics["total"].append(
-                    StatisticData(
-                        start=dt_util.as_local(data["datetime"]),
-                        state=data["value_kWh"],
-                        sum=_sum["total"],
-                    )
-                )
-                _sum[_p] += data["value_kWh"]
-                statistics[_p].append(
-                    StatisticData(
-                        start=dt_util.as_local(data["datetime"]),
-                        state=data["value_kWh"],
-                        sum=_sum[_p],
-                    )
-                )
-
-        for _scope in ["p1", "p2", "p3", "total"]:
-            metadata = StatisticMetaData(
-                has_mean=False,
-                has_sum=True,
-                name=f"{DOMAIN}_{scups} {_scope} energy consumption",
-                source=DOMAIN,
-                statistic_id=statistic_id[_scope],
-                unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-            )
-            async_add_external_statistics(hass, metadata, statistics[_scope])
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=f"edata_{scups}",
-        update_method=async_update_data,
-        update_interval=timedelta(minutes=30),
+    storage = await async_load_storage(store)
+    prev_data = (
+        {x: storage.get(x, []) for x in ["supplies", "contracts"]} if storage else None
     )
 
-    if prev_data:
-        coordinator.data = {
-            "state": STATE_LOADING,
-            "attributes": api.attributes,
-            "data": hass.data[DOMAIN][scups],
-        }
+    coordinator = EdataCoordinator(hass, usr, pwd, cups, prev_data)
+    if prev_data is not None:
+        await coordinator.compile_attributes()
 
     # postpone first refresh to speed up startup
     @callback
@@ -252,8 +149,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     if hass.state == CoreState.running:
         await async_first_refresh()
     else:
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, async_first_refresh)
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_first_refresh)
 
     # build sensor entities
 
@@ -279,17 +175,308 @@ class EdataSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        return (
-            self.coordinator.data.get("state", None)
-            if self.coordinator.data is not None
-            else None
-        )
+        try:
+            return self.coordinator.data.get("state", None)
+        except Exception as _:
+            return STATE_LOADING if self.coordinator.data is None else STATE_ERROR
 
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        return (
-            self.coordinator.data.get("attributes", {})
-            if self.coordinator.data is not None
-            else {}
+        try:
+            return self.coordinator.data.get("attributes", {})
+        except Exception as _:
+            return {}
+
+
+class EdataCoordinator(DataUpdateCoordinator):
+    """Handle Datadis data and statistics."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        username: str,
+        password: str,
+        cups: str,
+        prev_data=None,
+    ) -> None:
+        """Initialize the data handler."""
+        self.hass = hass
+        self.reset = prev_data is None
+
+        self._experimental = False
+        self._cups = cups.upper()
+        self.id = self._cups[-4:].lower()
+
+        self._data = {
+            "state": STATE_LOADING,
+            "attributes": {x: None for x in ATTRIBUTES},
+        }
+        if prev_data is not None:
+            self._data.update(prev_data)
+
+        self.consumption_stats = ["p1_kWh", "p2_kWh", "p3_kWh", "kWh"]
+        self.maximeter_stats = ["p1_kW", "p2_kW", "p3_kW", "kW"]
+
+        hass.data[DOMAIN][self.id.upper()] = {}
+
+        self.stat_ids = {
+            "kWh": f"{DOMAIN}:{self.id}_consumption",
+            "p1_kWh": f"{DOMAIN}:{self.id}_p1_consumption",
+            "p2_kWh": f"{DOMAIN}:{self.id}_p2_consumption",
+            "p3_kWh": f"{DOMAIN}:{self.id}_p3_consumption",
+            "kW": f"{DOMAIN}:{self.id}_maximeter",
+            "p1_kW": f"{DOMAIN}:{self.id}_p1_maximeter",
+            "p2_kW": f"{DOMAIN}:{self.id}_p2_maximeter",
+            "p3_kW": f"{DOMAIN}:{self.id}_p3_maximeter",
+        }
+
+        self._datadis = DatadisConnector(username, password, data=prev_data)
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"edata_{self.id}",
+            update_interval=SCAN_INTERVAL,
         )
+
+    async def _async_update_data(self):
+        """Update data via API."""
+        # reset stats if no storage file was found
+        if self.reset:
+            _LOGGER.warning(
+                "Clearing statistics for %s",
+                [self.stat_ids[x] for x in self.stat_ids],
+            )
+            await self.hass.async_add_executor_job(
+                clear_statistics,
+                self.hass.data[DATA_INSTANCE],
+                [self.stat_ids[x] for x in self.stat_ids],
+            )
+
+        # fetch last statistics found
+        last_stats = {
+            x: await self.hass.async_add_executor_job(
+                get_last_statistics, self.hass, 1, self.stat_ids[x], True
+            )
+            for x in self.stat_ids
+        }
+
+        # retrieve sum for summable stats (consumptions)
+        _sum = {
+            x: last_stats[x][self.stat_ids[x]][0].get("sum", 0) if last_stats[x] else 0
+            for x in self.consumption_stats
+        }
+
+        try:
+            last_kWh_record = last_stats["kWh"][self.stat_ids["kWh"]][0]["end"]
+            _LOGGER.info("Last consumptions record was at %s", last_kWh_record)
+        except KeyError as _:
+            last_kWh_record = None
+            _LOGGER.warning("No consumption stats found")
+
+        try:
+            last_kW_record = last_stats["kW"][self.stat_ids["kW"]][0]["end"]
+            _LOGGER.info("Last maximeter record was at %s", last_kW_record)
+        except KeyError as _:
+            last_kW_record = None
+            _LOGGER.warning("No maximeter stats found")
+
+        await self.hass.async_add_executor_job(
+            self._datadis.update,
+            self._cups,
+            min(
+                dt_util.parse_datetime(last_kWh_record).replace(tzinfo=None),
+                dt_util.parse_datetime(last_kW_record).replace(tzinfo=None),
+                datetime.today() - timedelta(days=30),
+            )
+            if last_kWh_record is not None and last_kW_record is not None
+            else datetime(1970, 1, 1),
+            datetime.today(),
+        )
+
+        self._data.update(self._datadis.data)
+
+        new_stats = {x: [] for x in self.stat_ids}
+        something_changed = False
+
+        _LABEL_kWh = "value_kWh"
+        for data in self._datadis.data.get("consumptions", {}):
+            if last_kWh_record is None or dt_util.as_local(
+                data["datetime"]
+            ) >= dt_util.parse_datetime(last_kWh_record):
+                something_changed = True
+                _p = du.get_pvpc_tariff(data["datetime"])
+                _sum["kWh"] += data[_LABEL_kWh]
+                new_stats["kWh"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]),
+                        state=data[_LABEL_kWh],
+                        mean=data[_LABEL_kWh],
+                        sum=_sum["kWh"],
+                    )
+                )
+                _sum[_p + "_kWh"] += data[_LABEL_kWh]
+                new_stats[_p + "_kWh"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]),
+                        state=data[_LABEL_kWh],
+                        mean=data[_LABEL_kWh],
+                        sum=_sum[_p + "_kWh"],
+                    )
+                )
+
+        _LABEL_kW = "value_kW"
+        for data in self._datadis.data.get("maximeter", {}):
+            if last_kW_record is None or dt_util.as_local(
+                data["datetime"]
+            ) >= dt_util.parse_datetime(last_kW_record):
+                something_changed = True
+                _p = du.get_pvpc_tariff(data["datetime"])
+                new_stats["kW"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]).replace(minute=0),
+                        state=data[_LABEL_kW],
+                        mean=data[_LABEL_kW],
+                    )
+                )
+                new_stats[_p + "_kW"].append(
+                    StatisticData(
+                        start=dt_util.as_local(data["datetime"]).replace(minute=0),
+                        state=data[_LABEL_kW],
+                        mean=data[_LABEL_kW],
+                    )
+                )
+
+        for _scope in self.consumption_stats:
+            metadata = StatisticMetaData(
+                has_mean=True,
+                has_sum=True,
+                name=f"{DOMAIN}_{self.id} {_scope} energy consumption",
+                source=DOMAIN,
+                statistic_id=self.stat_ids[_scope],
+                unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+            )
+            _LOGGER.info("adding new stats to %s", self.stat_ids[_scope])
+            async_add_external_statistics(self.hass, metadata, new_stats[_scope])
+
+        for _scope in self.maximeter_stats:
+            metadata = StatisticMetaData(
+                has_mean=True,
+                has_sum=False,
+                name=f"{DOMAIN}_{self.id} {_scope} maximeter",
+                source=DOMAIN,
+                statistic_id=self.stat_ids[_scope],
+                unit_of_measurement=POWER_KILO_WATT,
+            )
+            _LOGGER.info("adding new stats to %s", self.stat_ids[_scope])
+            async_add_external_statistics(self.hass, metadata, new_stats[_scope])
+
+        # compile state and attributes
+        if something_changed or self._data.get("state", STATE_LOADING) == STATE_LOADING:
+            # update state and attributes
+            self._data["state"] = STATE_READY
+            if (
+                False == await self.compile_attributes()
+            ):  # wipe data if something got wrong
+                _LOGGER.warning("Inconsistent data found, rebuilding statistics")
+                self.reset = True
+                await self._async_update_data()
+            # store if 24hs
+
+        return self._data
+
+    async def compile_attributes(self) -> bool:
+        """Load statistics and compile attributes and websockets, return false if failed"""
+        compiled_stats = {}
+
+        # load contractual data
+        attrs = {
+            "cups": self._cups
+            if self._cups in [x["cups"] for x in self._data["supplies"]]
+            else None,
+            "contract_p1_kW": self._data["contracts"][-1].get("power_p1", None)
+            if len(self._data["contracts"]) > 0
+            else None,
+            "contract_p2_kW": self._data["contracts"][-1].get("power_p2", None)
+            if len(self._data["contracts"]) > 0
+            else None,
+        }
+
+        # load consumptions
+        for _aggr_method in ("month", "day"):
+            _stats = await self.hass.async_add_executor_job(
+                statistics_during_period,
+                self.hass,
+                dt_util.as_local(datetime(1970, 1, 1)),
+                None,
+                [self.stat_ids[x] for x in self.consumption_stats],
+                _aggr_method,
+            )
+            compiled_stats[_aggr_method] = {}
+            for hourly_stat in _stats:
+                _sum = 0
+                for i in _stats[hourly_stat]:
+                    _dt = dt_util.as_local(dt_util.parse_datetime(i["start"]))
+                    date = _dt.isoformat()
+                    if date not in compiled_stats[_aggr_method]:
+                        compiled_stats[_aggr_method][date] = {
+                            "datetime": date,
+                            "value_kWh": 0,
+                            "value_p1_kWh": 0,
+                            "value_p2_kWh": 0,
+                            "value_p3_kWh": 0,
+                        }
+                    for _scope in self.consumption_stats:
+                        if self.stat_ids[_scope] == i["statistic_id"]:
+                            _key = f"value_{_scope}"
+                            _inc = round(i["sum"] - _sum, 2)
+                            compiled_stats[_aggr_method][date][_key] = _inc
+                            _sum = i["sum"]
+                            if _inc < 0:
+                                return False
+                            break
+
+            # load into websockets
+            self.hass.data[DOMAIN][self.id.upper()][
+                f"ws_consumptions_{_aggr_method}"
+            ] = sorted(
+                [compiled_stats[_aggr_method][x] for x in compiled_stats[_aggr_method]],
+                key=lambda d: dt_util.parse_datetime(d["datetime"]),
+            )
+
+        # load yesterday attributes
+        ydates = day_start_end(datetime.now() - timedelta(days=1))
+        _date_str = dt_util.as_local(ydates[0]).isoformat()
+        if _date_str in compiled_stats["day"]:
+            attrs["yesterday_kWh"] = compiled_stats["day"][_date_str]["value_kWh"]
+            attrs["yesterday_p1_kWh"] = compiled_stats["day"][_date_str]["value_p1_kWh"]
+            attrs["yesterday_p2_kWh"] = compiled_stats["day"][_date_str]["value_p2_kWh"]
+            attrs["yesterday_p3_kWh"] = compiled_stats["day"][_date_str]["value_p3_kWh"]
+        # load current month attributes
+        cmdates = month_start_end(datetime.now().replace(day=1))
+        _date_str = dt_util.as_local(cmdates[0]).isoformat()
+        if _date_str in compiled_stats["month"]:
+            attrs["month_kWh"] = compiled_stats["month"][_date_str]["value_kWh"]
+            attrs["month_p1_kWh"] = compiled_stats["month"][_date_str]["value_p1_kWh"]
+            attrs["month_p2_kWh"] = compiled_stats["month"][_date_str]["value_p2_kWh"]
+            attrs["month_p3_kWh"] = compiled_stats["month"][_date_str]["value_p3_kWh"]
+        # load last month attributes
+        lmdates = month_start_end(cmdates[0] - relativedelta(months=1))
+        _date_str = dt_util.as_local(lmdates[0]).isoformat()
+        if _date_str in compiled_stats["month"]:
+            attrs["last_month_kWh"] = compiled_stats["month"][_date_str]["value_kWh"]
+            attrs["last_month_p1_kWh"] = compiled_stats["month"][_date_str][
+                "value_p1_kWh"
+            ]
+            attrs["last_month_p2_kWh"] = compiled_stats["month"][_date_str][
+                "value_p2_kWh"
+            ]
+            attrs["last_month_p3_kWh"] = compiled_stats["month"][_date_str][
+                "value_p3_kWh"
+            ]
+
+        # update attributes
+        self._data["attributes"].update(attrs)
+
+        return True

--- a/websockets.py
+++ b/websockets.py
@@ -14,14 +14,14 @@ def websocket_get_daily_data(hass, connection, msg):
     """Publish daily consumptions list data."""
     try:
         data = hass.data[DOMAIN][msg["scups"].upper()].get("ws_consumptions_day", [])
-        filtered_data = data[-30:]
+        filtered_data = data[-msg.get("records", 30) :]
         connection.send_result(msg["id"], filtered_data)
-    except KeyError as e:
+    except KeyError as _:
         _LOGGER.error(
-            "the provided scups parameter is not correct: %s", msg["scups"].upper()
+            "The provided scups parameter is not correct: %s", msg["scups"].upper()
         )
-    except Exception as e:
-        _LOGGER.exception("unhandled exception when processing websockets", e)
+    except Exception as _:
+        _LOGGER.exception("Unhandled exception when processing websockets", _)
         connection.send_result(msg["id"], [])
 
 
@@ -33,12 +33,12 @@ def websocket_get_monthly_data(hass, connection, msg):
             msg["id"],
             hass.data[DOMAIN][msg["scups"].upper()].get("ws_consumptions_month", []),
         )
-    except KeyError as e:
+    except KeyError as _:
         _LOGGER.error(
-            "the provided scups parameter is not correct: %s", msg["scups"].upper()
+            "The provided scups parameter is not correct: %s", msg["scups"].upper()
         )
-    except Exception as e:
-        _LOGGER.exception("unhandled exception when processing websockets", e)
+    except Exception as _:
+        _LOGGER.exception("Unhandled exception when processing websockets", _)
         connection.send_result(msg["id"], [])
 
 
@@ -47,14 +47,14 @@ def websocket_get_maximeter(hass, connection, msg):
     """Publish maximeter list data."""
     try:
         connection.send_result(
-            msg["id"], hass.data[DOMAIN][msg["scups"].upper()].get("maximeter", [])
+            msg["id"], hass.data[DOMAIN][msg["scups"].upper()].get("ws_maximeter", [])
         )
-    except KeyError as e:
+    except KeyError as _:
         _LOGGER.error(
-            "the provided scups parameter is not correct: %s", msg["scups"].upper()
+            "The provided scups parameter is not correct: %s", msg["scups"].upper()
         )
-    except Exception as e:
-        _LOGGER.exception("unhandled exception when processing websockets", e)
+    except Exception as _:
+        _LOGGER.exception("Unhandled exception when processing websockets", _)
         connection.send_result(msg["id"], [])
 
 
@@ -67,6 +67,7 @@ def async_register_websockets(hass):
             {
                 vol.Required("type"): f"{DOMAIN}/consumptions/daily",
                 vol.Required("scups"): str,
+                vol.Optional("records"): int,
             }
         ),
     )
@@ -78,6 +79,7 @@ def async_register_websockets(hass):
             {
                 vol.Required("type"): f"{DOMAIN}/consumptions/monthly",
                 vol.Required("scups"): str,
+                vol.Optional("records"): int,
             }
         ),
     )
@@ -86,6 +88,10 @@ def async_register_websockets(hass):
         f"{DOMAIN}/maximeter",
         websocket_get_maximeter,
         websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
-            {vol.Required("type"): f"{DOMAIN}/maximeter", vol.Required("scups"): str}
+            {
+                vol.Required("type"): f"{DOMAIN}/maximeter",
+                vol.Required("scups"): str,
+                vol.Optional("records"): int,
+            }
         ),
     )

--- a/websockets.py
+++ b/websockets.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timedelta
 
 import voluptuous as vol
 from homeassistant.components import websocket_api
@@ -14,24 +13,12 @@ _LOGGER = logging.getLogger(__name__)
 def websocket_get_daily_data(hass, connection, msg):
     """Publish daily consumptions list data."""
     try:
-        data = hass.data[DOMAIN][msg["scups"].upper()].get(
-            "consumptions_daily_sum", [])
-        filtered_data = [
-            x
-            for x in data
-            if (
-                (
-                    datetime.today().date()
-                    - datetime.strptime(x["datetime"], "%Y-%m-%d").date()
-                )
-                < timedelta(days=30)
-            )
-        ]
+        data = hass.data[DOMAIN][msg["scups"].upper()].get("ws_consumptions_day", [])
+        filtered_data = data[-30:]
         connection.send_result(msg["id"], filtered_data)
     except KeyError as e:
         _LOGGER.error(
-            "the provided scups parameter is not correct: %s", msg["scups"].upper(
-            )
+            "the provided scups parameter is not correct: %s", msg["scups"].upper()
         )
     except Exception as e:
         _LOGGER.exception("unhandled exception when processing websockets", e)
@@ -44,13 +31,11 @@ def websocket_get_monthly_data(hass, connection, msg):
     try:
         connection.send_result(
             msg["id"],
-            hass.data[DOMAIN][msg["scups"].upper()].get(
-                "consumptions_monthly_sum", []),
+            hass.data[DOMAIN][msg["scups"].upper()].get("ws_consumptions_month", []),
         )
     except KeyError as e:
         _LOGGER.error(
-            "the provided scups parameter is not correct: %s", msg["scups"].upper(
-            )
+            "the provided scups parameter is not correct: %s", msg["scups"].upper()
         )
     except Exception as e:
         _LOGGER.exception("unhandled exception when processing websockets", e)
@@ -66,8 +51,7 @@ def websocket_get_maximeter(hass, connection, msg):
         )
     except KeyError as e:
         _LOGGER.error(
-            "the provided scups parameter is not correct: %s", msg["scups"].upper(
-            )
+            "the provided scups parameter is not correct: %s", msg["scups"].upper()
         )
     except Exception as e:
         _LOGGER.exception("unhandled exception when processing websockets", e)
@@ -102,7 +86,6 @@ def async_register_websockets(hass):
         f"{DOMAIN}/maximeter",
         websocket_get_maximeter,
         websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
-            {vol.Required("type"): f"{DOMAIN}/maximeter",
-             vol.Required("scups"): str}
+            {vol.Required("type"): f"{DOMAIN}/maximeter", vol.Required("scups"): str}
         ),
     )


### PR DESCRIPTION
### Goal:
* Define custom DataUpdateCoordinator and mimic EdataHelper behavior by directly calling connectors
* Save/load data in builtin statistics instead of storing in `.storage` file
* Autodetect bad stored data and fetch again

### Done:
* Consumptions and maximeter are saved into builtin statistics (note: maximeter cannot be stored at quarter-hour multiple times)
* Consumptions are read from builtin statistics
* Read maximeter from builtin statistics
* Generate attribute values from builtin statistics
* Keep storing `supplies` and `contracts` data in `.storage` file
* Move `EdataCoordinator` from `sensor.py` to `coordinator.py`