### PR TITLE
fix: guard against empty consumption data in integrity check (#320)

### DIFF
--- a/custom_components/edata/coordinator.py
+++ b/custom_components/edata/coordinator.py
@@ -313,9 +313,15 @@ class EdataCoordinator(DataUpdateCoordinator):
         await asyncio.to_thread(self._edata.process_data, False)
 
         # give from_dt a proper default value
-        from_dt = dt_util.as_utc(
-            self._edata.data["consumptions_daily_sum"][0]["datetime"]
-        )
+        daily_sum = self._edata.data.get("consumptions_daily_sum") or []
+        if not daily_sum:
+            _LOGGER.warning(
+                "%s: no consumption data available, skipping integrity check",
+                self.scups,
+            )
+            return False
+
+        from_dt = dt_util.as_utc(daily_sum[0]["datetime"])
 
         _LOGGER.debug(
             "%s: performing integrity check since %s",


### PR DESCRIPTION
Resolves #320.

`check_statistics_integrity()` indexed `consumptions_daily_sum[0]` unconditionally, raising `IndexError` when no consumption data has been loaded yet (e.g. when the contracts lookup fails with 'contracts update failed or no contracts found in the provided account'). The Soft reset / Restablecer button surfaces the crash as: `No se pudo realizar la acción button/press. list index out of range`.

Guards the access using the snippet suggested in the issue: skip the integrity check and return `False` with a warning when the list is empty so the button reports a clean failure instead of crashing.

Tested locally with the file syntax-checked; the integration cannot be loaded outside Home Assistant without HA dependencies, so no unit test was added (the repo has none).